### PR TITLE
fix: Add non-interactive Docker environment for SWE-bench evaluation

### DIFF
--- a/evaluation/swe_bench/scripts/docker/docker_env.sh
+++ b/evaluation/swe_bench/scripts/docker/docker_env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Set Docker to run non-interactively
+export DOCKER_BUILDKIT=1
+export DOCKER_SCAN_SUGGEST=false
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to run Docker commands with yes piped in
+docker_noninteractive() {
+    yes | "$@"
+}
+
+# Alias docker to use the non-interactive function
+alias docker=docker_noninteractive

--- a/evaluation/swe_bench/scripts/docker/pull_all_eval_docker.sh
+++ b/evaluation/swe_bench/scripts/docker/pull_all_eval_docker.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# Source the Docker environment settings
+source "$(dirname "$0")/docker_env.sh"
+
+LEVEL=$1
+# three levels:
+# - base, keyword "sweb.base"
+# - env, keyword "sweb.env"
+# - instance, keyword "sweb.eval"
+SET=$2
+
+if [ -z "$LEVEL" ]; then
+    echo "Usage: $0 <cache_level> <set>"
+    echo "cache_level: base, env, or instance"
+    echo "set: lite, full"
+    exit 1
+fi
+
+if [ -z "$SET" ]; then
+    echo "Usage: $0 <cache_level> <set>"
+    echo "cache_level: base, env, or instance"
+    echo "set: lite, full, default is lite"
+    SET="lite"
+fi
+
+# Check if namespace is provided via argument $3, otherwise default to 'xingyaoww'
+NAMESPACE=${3:-xingyaoww}
+
+echo "Using namespace: $NAMESPACE"
+
+if [ "$SET" == "lite" ]; then
+    IMAGE_FILE="$(dirname "$0")/all-swebench-lite-instance-images.txt"
+else
+    IMAGE_FILE="$(dirname "$0")/all-swebench-full-instance-images.txt"
+fi
+
+# Define a pattern based on the level
+case $LEVEL in
+    base)
+        PATTERN="sweb.base"
+        ;;
+    env)
+        PATTERN="sweb.base\|sweb.env"
+        ;;
+    instance)
+        PATTERN="sweb.base\|sweb.env\|sweb.eval"
+        ;;
+    *)
+        echo "Invalid cache level: $LEVEL"
+        echo "Valid levels are: base, env, instance"
+        exit 1
+        ;;
+esac
+
+echo "Pulling docker images for [$LEVEL] level"
+
+echo "Pattern: $PATTERN"
+echo "Image file: $IMAGE_FILE"
+
+# Read each line from the file, filter by pattern, and pull the docker image
+grep "$PATTERN" "$IMAGE_FILE" | while IFS= read -r image; do
+    echo "Pulling $NAMESPACE/$image into $image"
+    docker pull $NAMESPACE/$image
+    # replace _s_ to __ in the image name
+    renamed_image=$(echo "$image" | sed 's/_s_/__/g')
+    docker tag $NAMESPACE/$image $renamed_image
+done


### PR DESCRIPTION
This PR fixes the Docker build issue where it gets stuck on "Delete 1061 entries? (yes/no) [yes] Aborted" by:

1. Adding a new `docker_env.sh` script that sets up non-interactive Docker environment
2. Modifying the Docker environment to automatically handle confirmations
3. Updating the pull script to use these non-interactive settings

The changes ensure that Docker commands run without requiring manual intervention while maintaining the same functionality.

Note: This PR has been updated to include the latest changes from upstream/main.