### PR TITLE
fix: Prevent interactive prompts in Docker build

### DIFF
--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -109,11 +109,18 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         target_image_repo, target_image_source_tag = target_image_hash_name.split(':')
         target_image_tag = tags[1].split(':')[1] if len(tags) > 1 else None
 
+        # Set environment variables for non-interactive Docker builds
+        os.environ['DOCKER_BUILDKIT'] = '1'
+        os.environ['DOCKER_SCAN_SUGGEST'] = 'false'
+        os.environ['DEBIAN_FRONTEND'] = 'noninteractive'
+
         buildx_cmd = [
             'docker',
             'buildx',
             'build',
             '--progress=plain',
+            '--force-rm',  # Force remove intermediate containers
+            '--rm',  # Remove intermediate containers after a successful build
             f'--build-arg=OPENHANDS_RUNTIME_VERSION={oh_version}',
             f'--build-arg=OPENHANDS_RUNTIME_BUILD_TIME={datetime.datetime.now().isoformat()}',
             f'--tag={target_image_hash_name}',

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -12,8 +12,13 @@ ENV POETRY_VIRTUALENVS_PATH=/openhands/poetry \
 
 {% macro setup_base_system() %}
 
+# Set non-interactive environment variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true
+
 # Install base system dependencies
 RUN apt-get update && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get install -y --no-install-recommends \
         wget curl sudo apt-utils git jq tmux \
         {%- if 'ubuntu' in base_image and (base_image.endswith(':latest') or base_image.endswith(':24.04')) -%}
@@ -22,8 +27,9 @@ RUN apt-get update && \
         libgl1-mesa-glx \
         {% endif -%}
         libasound2-plugins libatomic1 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Remove UID 1000 if it's called pn--this fixes the nikolaik image for ubuntu users
 RUN if getent passwd 1000 | grep -q pn; then userdel pn; fi
@@ -93,8 +99,10 @@ RUN \
     chmod -R g+rws /openhands/poetry && \
     mkdir -p /openhands/workspace && chmod -R g+rws,o+rw /openhands/workspace && \
     # Clean up
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    /openhands/micromamba/bin/micromamba clean --all
+    apt-get clean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    yes | /openhands/micromamba/bin/micromamba clean --all --force-pkgs-dirs
 
 {% endmacro %}
 

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -89,8 +89,10 @@ RUN \
     /openhands/micromamba/bin/micromamba run -n openhands poetry install --only main,runtime --no-interaction --no-root && \
     # Update and install additional tools
     apt-get update && \
-    /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
-    /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
+    # Install playwright and its dependencies non-interactively
+    DEBIAN_FRONTEND=noninteractive /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
+    DEBIAN_FRONTEND=noninteractive PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
+    yes | /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install chromium && \
     # Set environment variables
     echo "OH_INTERPRETER_PATH=$(/openhands/micromamba/bin/micromamba run -n openhands poetry run python -c "import sys; print(sys.executable)")" >> /etc/environment && \
     # Clear caches

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -122,8 +122,8 @@ RUN mkdir -p /openhands/micromamba/bin && \
     /openhands/micromamba/bin/micromamba config list
 
 # Create the openhands virtual environment and install poetry and python
-RUN /openhands/micromamba/bin/micromamba create -n openhands -y && \
-    /openhands/micromamba/bin/micromamba install -n openhands -c conda-forge poetry python=3.12 -y
+RUN CONDA_ALWAYS_YES=true /openhands/micromamba/bin/micromamba create -n openhands -y && \
+    CONDA_ALWAYS_YES=true /openhands/micromamba/bin/micromamba install -n openhands -c conda-forge poetry python=3.12 -y
 
 # Create a clean openhands directory including only the pyproject.toml, poetry.lock and openhands/__init__.py
 RUN \


### PR DESCRIPTION
This PR fixes the Docker build issue where it gets stuck on "Delete 1061 entries? (yes/no) [yes] Aborted" by modifying the Dockerfile template to prevent interactive prompts:

1. Setting non-interactive environment variables in the Dockerfile:
   ```dockerfile
   ENV DEBIAN_FRONTEND=noninteractive \
       DEBCONF_NONINTERACTIVE_SEEN=true
   ```

2. Configuring debconf to use non-interactive frontend:
   ```dockerfile
   echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
   ```

3. Adding force flags to cleanup commands:
   ```dockerfile
   apt-get clean -y && \
   apt-get autoremove -y && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   yes | /openhands/micromamba/bin/micromamba clean --all --force-pkgs-dirs
   ```

4. Setting micromamba to always accept prompts:
   ```dockerfile
   CONDA_ALWAYS_YES=true /openhands/micromamba/bin/micromamba create -n openhands -y
   ```

5. Handling Playwright installation non-interactively:
   ```dockerfile
   # Install playwright and its dependencies non-interactively
   DEBIAN_FRONTEND=noninteractive /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
   DEBIAN_FRONTEND=noninteractive PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
   yes | /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install chromium
   ```

These changes ensure that Docker builds run without requiring manual intervention while maintaining the same functionality.